### PR TITLE
feat: Add custom background and hover descriptions

### DIFF
--- a/showcase/README.md
+++ b/showcase/README.md
@@ -51,6 +51,15 @@ This application is designed to be run inside a Docker container.
     docker stop <container_id_or_name>
     ```
 
+## Customizing the Gallery Background
+
+You can add a custom background to the showcase gallery wall.
+
+1.  Find an image you want to use as the background.
+2.  Name it `showcase_background.jpg` (or `.png`, or `.gif`).
+3.  Place this file inside the `showcase/static/images/` directory.
+4.  If running in Docker, rebuild your image and run the container. The app will automatically detect and use your custom background.
+
 ## Development (Alternative - Running directly with Flask)
 
 If you prefer to run the Flask development server directly without Docker (e.g., for quick local development):

--- a/showcase/app.py
+++ b/showcase/app.py
@@ -24,7 +24,7 @@ def get_galleries_data():
     gallery_dirs = [g for g in os.listdir(base_path) if os.path.isdir(os.path.join(base_path, g))]
     gallery_dirs = natsort.natsorted(gallery_dirs)
 
-    for gallery_name in gallery_dirs:
+    for i, gallery_name in enumerate(gallery_dirs):
         gallery_path = os.path.join(base_path, gallery_name)
 
         # Thumbnail is ALWAYS from stage 3
@@ -40,11 +40,15 @@ def get_galleries_data():
                 # Use the real image path if it exists
                 thumbnail_path = f'galleries/{gallery_name}/{last_stage_name}/{stage_images[0]}'
 
+        # Assign a random size class for varied layout
+        size_class = 'grid-item--width2' if i % 4 == 0 else ''
+
         galleries.append({
             'id': gallery_name,
             'name': gallery_name.replace('-', ' ').title(),
             'description': f'A collection from {gallery_name.replace("-", " ").title()}. View the developmental trail of the artwork.',
-            'thumbnail': url_for('static', filename=thumbnail_path)
+            'thumbnail': url_for('static', filename=thumbnail_path),
+            'size_class': size_class
         })
 
     return galleries
@@ -95,11 +99,21 @@ def home():
     """Renders the home page."""
     return render_template('home.html')
 
+def find_custom_background():
+    """Checks for a custom background image."""
+    image_dir = os.path.join(app.static_folder, 'images')
+    for ext in ['.png', '.jpg', '.jpeg', '.gif']:
+        filename = 'showcase_background' + ext
+        if os.path.exists(os.path.join(image_dir, filename)):
+            return url_for('static', filename=f'images/{filename}')
+    return None
+
 @app.route('/showcase/')
 def showcase_galleries():
     """Renders the showcase gallery overview page with dynamically found galleries."""
     galleries = get_galleries_data()
-    return render_template('showcase_galleries.html', galleries=galleries)
+    custom_background = find_custom_background()
+    return render_template('showcase_galleries.html', galleries=galleries, custom_background=custom_background)
 
 @app.route('/showcase/gallery/<gallery_id>')
 def gallery_detail(gallery_id):

--- a/showcase/static/css/style.css
+++ b/showcase/static/css/style.css
@@ -234,56 +234,70 @@ header {
     background-image: linear-gradient(to right, #dd5e89 0%, #f7bb97 51%, #dd5e89 100%);
 }
 
-/* Gallery Grid */
+/* Gallery Grid (Masonry container) */
 .gallery-grid {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 30px;
-    margin-top: 20px;
-    padding: 0 2%; /* Reduced padding to fit more */
+    margin: 0 auto;
+    padding: 20px;
+    background-color: #f3f0e9; /* A warm, wall-like color */
+    background-image: url("https://www.transparenttextures.com/patterns/subtle-white-feathers.png"); /* Subtle texture */
+}
+
+.grid-sizer,
+.gallery-card {
+    width: 23%; /* Base width for items */
+}
+
+.gallery-card.grid-item--width2 {
+    width: 48%; /* Double width for specific items */
 }
 
 .gallery-card {
-    flex: 0 1 280px;
-    border-radius: 8px;
+    margin-bottom: 20px;
+    border-radius: 4px;
     background-color: #fff;
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     overflow: hidden;
-    box-shadow: 0 4px 6px rgba(0,0,0,0.1);
-    display: flex;
-    flex-direction: column;
+    box-shadow: 0 5px 15px rgba(0,0,0,0.2);
 }
 
 .gallery-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 15px rgba(0,0,0,0.1);
+    transform: scale(1.03);
+    box-shadow: 0 10px 25px rgba(0,0,0,0.3);
+    z-index: 10;
 }
 
 .gallery-card img {
     width: 100%;
-    height: 180px; /* Landscape aspect ratio */
-    object-fit: cover; /* Fill the container, cropping if necessary */
+    height: auto; /* Let height be determined by image aspect ratio */
+    display: block;
 }
 
-.gallery-card-content {
+.card-overlay {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(0, 0, 0, 0.7);
+    color: white;
     padding: 15px;
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1; /* Ensure this container grows to fill space */
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    text-align: left;
 }
 
-.gallery-card h3 {
+.gallery-card:hover .card-overlay {
+    opacity: 1;
+}
+
+.card-overlay h3 {
     margin: 0 0 5px 0;
     font-size: 1.2em;
     font-weight: 700;
 }
 
-.gallery-card p {
+.card-overlay p {
     font-size: 0.9em;
-    color: #555;
     margin: 0;
-    /* Removed single-line truncation properties */
 }
 
 .gallery-card a {

--- a/showcase/static/js/gallery-layout.js
+++ b/showcase/static/js/gallery-layout.js
@@ -1,0 +1,17 @@
+// This script initializes the Masonry layout for the gallery grid.
+
+document.addEventListener('DOMContentLoaded', function() {
+    const grid = document.querySelector('.gallery-grid');
+
+    if (grid) {
+        // Initialize Masonry after all images have been loaded
+        imagesLoaded(grid, function() {
+            new Masonry(grid, {
+                itemSelector: '.gallery-card',
+                columnWidth: '.grid-sizer', // Use a sizer element for column width
+                percentPosition: true,
+                gutter: 20 // The space between items
+            });
+        });
+    }
+});

--- a/showcase/templates/layout.html
+++ b/showcase/templates/layout.html
@@ -46,5 +46,9 @@
     </div>
 
     <script src="{{ url_for('static', filename='js/main.js') }}"></script>
+    <!-- Masonry & ImagesLoaded CDN -->
+    <script src="https://unpkg.com/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
+    <script src="https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js"></script>
+    <script src="{{ url_for('static', filename='js/gallery-layout.js') }}"></script>
 </body>
 </html>

--- a/showcase/templates/showcase_galleries.html
+++ b/showcase/templates/showcase_galleries.html
@@ -5,15 +5,17 @@
 {% block content %}
 <div class="gallery-header">
     <h2>Showcase Galleries</h2>
-    <p>Click on a gallery to view the artist's developmental trail and artwork.</p>
+    <p>A collection of developmental trails and artworks.</p>
 </div>
-<div class="gallery-grid">
+<div class="gallery-grid" {% if custom_background %}style="background-image: url('{{ custom_background }}'); background-size: cover; background-position: center;"{% endif %}>
+    <!-- Grid sizer for Masonry -->
+    <div class="grid-sizer"></div>
     {% if galleries %}
         {% for gallery in galleries %}
-        <div class="gallery-card">
+        <div class="gallery-card {{ gallery.size_class }}">
             <a href="{{ url_for('gallery_detail', gallery_id=gallery.id) }}">
-                <img src="{{ gallery.thumbnail }}" alt="{{ gallery.name }} Thumbnail">
-                <div class="gallery-card-content">
+                <img src="{{ gallery.thumbnail }}" alt="{{ gallery.name }} Thumbnail" class="gallery-thumbnail">
+                <div class="card-overlay">
                     <h3>{{ gallery.name }}</h3>
                     <p>{{ gallery.description }}</p>
                 </div>
@@ -21,7 +23,7 @@
         </div>
         {% endfor %}
     {% else %}
-        <p>No galleries found. Add some in the <code>showcase/static/galleries/</code> directory.</p>
+        <p class="no-galleries-message">No galleries found. Add some in the <code>showcase/static/galleries/</code> directory.</p>
     {% endif %}
 </div>
 {% endblock %}


### PR DESCRIPTION
- The app now automatically detects and uses a `showcase_background.jpg` (or .png) file in `static/images` as the gallery wall background.
- Gallery cards now feature a hover-to-show overlay with the gallery's title and description.
- Updated the README with instructions for the new custom background feature.